### PR TITLE
babel-generator should be a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "ava": "0.17.x",
     "babel-cli": "6.18.x",
     "babel-core": "6.18.x",
-    "babel-generator": "6.19.0",
     "eslint": "3.10.x",
     "flow-bin": "0.35.x",
     "flow-typed": "2.0.x",
     "fs-extra": "1.0.0"
   },
   "dependencies": {
+    "babel-generator": "6.19.0",
     "babel-types": "6.19.0",
     "lodash": "4.17.x"
   },


### PR DESCRIPTION
babel-generator is used in src/index.js, so it needs to be a regular dependency