### PR TITLE
Multiple properties are not merged properly when using allOf

### DIFF
--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 30b961321e07b9c4220a08ccb1df90a6
-// flow-typed version: b8b7c5fef5/lodash_v4.x.x/flow_>=v0.28.x
+// flow-typed signature: 768caa5b8c6f35fa3e25ea339769a565
+// flow-typed version: e26b789976/lodash_v4.x.x/flow_>=v0.28.x_<=v0.37.x
 
 declare module 'lodash' {
   declare type TemplateSettings = {
@@ -29,27 +29,39 @@ declare module 'lodash' {
 
   declare type NestedArray<T> = Array<Array<T>>;
 
+  declare type matchesIterateeShorthand = Object;
+  declare type matchesPropertyIterateeShorthand = [string, any];
+  declare type propertyIterateeShorthand = string;
+
   declare type OPredicate<A, O> =
-                    | ((value: A, key: string, object: O) => any)
-                    | Object
-                    | string;
+    | ((value: A, key: string, object: O) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
   declare type OIterateeWithResult<V, O, R> = Object|string|((value: V, key: string, object: O) => R);
   declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
+  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, T, Array<U>>;
 
   declare type Predicate<T> =
-                    | ((value: T, index: number, array: Array<T>) => any)
-                    | Object
-                    | string;
+    | ((value: T, index: number, array: Array<T>) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
   declare type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
   declare type Iteratee<T> = _Iteratee<T>|Object|string;
   declare type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;
   declare type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
   declare type Comparator<T> = (item: T, item2: T) => bool;
 
-  declare type MapIterator1<T,U> = (item: T) => U;
-  declare type MapIterator2<T,U> = (item: T, index: number) => U;
-  declare type MapIterator3<T,U> = (item: T, index: number, array: Array<T>) => U;
-  declare type MapIterator<T,U> = MapIterator1<T,U>|MapIterator2<T,U>|MapIterator3<T,U>;
+  declare type MapIterator<T,U> =
+    | ((item: T, index: number, array: Array<T>) => U)
+    | propertyIterateeShorthand;
+
+  declare type OMapIterator<T,O,U> =
+    | ((item: T, key: string, object: O) => U)
+    | propertyIterateeShorthand;
 
   declare class Lodash {
     // Array
@@ -171,8 +183,11 @@ declare module 'lodash' {
     findLast<T>(array: ?Array<T>, predicate?: Predicate<T>): T;
     findLast<V, A, T: {[id: string]: A}>(object: T, predicate?: OPredicate<A, T>): V;
     flatMap<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>): Array<U>;
+    flatMap<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>): Array<U>;
     flatMapDeep<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>): Array<U>;
+    flatMapDeep<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>): Array<U>;
     flatMapDepth<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>, depth?: number): Array<U>;
+    flatMapDepth<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>, depth?: number): Array<U>;
     forEach<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
     forEach<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     forEachRight<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
@@ -184,10 +199,10 @@ declare module 'lodash' {
     includes(str: string, value: string, fromIndex?: number): bool;
     invokeMap<T>(array: ?Array<T>, path: ((value: T) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     invokeMap<T: Object>(object: T, path: ((value: any) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
-    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): {[key: V]: T};
+    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): {[key: V]: ?T};
     keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
-    map<V, T: Object, U>(object: ?T, iteratee?: OIterateeWithResult<V, T, U>): Array<U>;
+    map<V, T: Object, U>(object: ?T, iteratee?: OMapIterator<V, T, U>): Array<U>;
     map(str: ?string, iteratee?: (char: string, index: number, str: string) => any): string;
     orderBy<T>(array: ?Array<T>, iteratees?: Array<Iteratee<T>>|string, orders?: Array<'asc'|'desc'>|string): Array<T>;
     orderBy<V, T: Object>(object: T, iteratees?: Array<OIteratee<*>>|string, orders?: Array<'asc'|'desc'>|string): Array<V>;
@@ -286,7 +301,8 @@ declare module 'lodash' {
     isRegExp(value: any): bool;
     isSafeInteger(value: any): bool;
     isSet(value: any): bool;
-    isString(value: any): bool;
+    isString(value: string): true;
+    isString(value: number|Function|void|null|Object|Array<any>): false;
     isSymbol(value: any): bool;
     isTypedArray(value: any): bool;
     isUndefined(value: any): bool;
@@ -483,7 +499,8 @@ declare module 'lodash' {
     stubObject(): {};
     stubString(): '';
     stubTrue(): true;
-    times(n: number, iteratee?: Function): Function;
+    times(n: number, ...rest: Array<void>): Array<number>;
+    times<T>(n: number, iteratee: ((i: number) => T)): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: string): string;
 

--- a/src/FlowSchema.js
+++ b/src/FlowSchema.js
@@ -125,7 +125,7 @@ export const convertSchema = (schema: Schema): FlowSchema => {
   if (schema.allOf) {
     const patchedSchema = _.reduce(
       schema.allOf,
-      (prev: Schema, item: Schema) => _.assign(prev, item),
+      (prev: Schema, item: Schema) => _.merge(prev, item),
       _.omit(schema, ['allOf', '$ref']),
     );
 

--- a/src/__tests__/FlowSchema.spec.js
+++ b/src/__tests__/FlowSchema.spec.js
@@ -30,16 +30,16 @@ test('should convert multiple　properties by allOf', (t) => {
         type: 'object',
         properties: {
           string: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       }, {
         type: 'object',
         properties: {
           number: {
-            type: 'number'
-          }
-        }
+            type: 'number',
+          },
+        },
       }],
     }),
 

--- a/src/__tests__/FlowSchema.spec.js
+++ b/src/__tests__/FlowSchema.spec.js
@@ -22,6 +22,35 @@ test('should convert allOf', (t) => {
   );
 });
 
+test('should convert multiple　properties by allOf', (t) => {
+  t.deepEqual(
+    convertSchema({
+      id: 'AllOf',
+      allOf: [{
+        type: 'object',
+        properties: {
+          string: {
+            type: 'string'
+          }
+        }
+      }, {
+        type: 'object',
+        properties: {
+          number: {
+            type: 'number'
+          }
+        }
+      }],
+    }),
+
+    flow('Object')
+      .props({
+        string: flow('string'),
+        number: flow('number'),
+      }).id('AllOf'),
+  );
+});
+
 test('should convert enum', (t) => {
   t.deepEqual(
     convertSchema({


### PR DESCRIPTION
Hi. I noticed, multiple properties are not merged properly when using allOf.

- shcema
```
{
  "id": "sample",
  "$schema": "http://json-schema.org/draft-04/schema#",
  "definitions": {
    "foo": {
      "allOf": [
        {
          "type": "object",
          "properties": {
            "foo": {
              "type": "number"
            }
          }
        },
        {
          "type": "object",
          "properties": {
            "bar": {
              "type": "number"
            }
          }
        }
      ]
    }
  }
}
```

That schema is converted to bellow flowtype.

```
export type Foo = {
  bar?: number;
};

export type Sample = any;
```

But, I think it should be of the type as below.

```
export type Foo = {
  foo?: number;
  bar?: number;
};

export type Sample = any;
```



