### PR TITLE
Handle OneOf With Properties

### DIFF
--- a/definitions/Schema.js
+++ b/definitions/Schema.js
@@ -3,6 +3,16 @@
 
 export type SchemaArray = Array<Schema>;
 
+export type Inheritance = {
+  key1?: string;
+  key2?: string;
+  key3?: any;
+} | {
+  key1?: string;
+  key2?: string;
+  key4?: any;
+};
+
 export type PositiveInteger = number;
 
 export type PositiveIntegerDefault0 = PositiveInteger;

--- a/definitions/Swagger.js
+++ b/definitions/Swagger.js
@@ -1,6 +1,16 @@
 // @flow
 /* eslint-disable */
 
+export type Inheritance = {
+  key1?: string;
+  key2?: string;
+  key3?: any;
+} | {
+  key1?: string;
+  key2?: string;
+  key4?: any;
+};
+
 export type Info = {
   title: string;
   version: string;

--- a/src/FlowSchema.js
+++ b/src/FlowSchema.js
@@ -167,7 +167,16 @@ export const convertSchema = (schema: Schema): FlowSchema => {
     );
   }
 
-  if (schema.oneOf) {
+  if (schema.oneOf && schema.properties) {
+    const oneOfs = _.map(schema.oneOf, oneOf => ({
+      ...oneOf,
+      properties: {
+        ...schema.properties,
+        ...oneOf.properties,
+      },
+    }));
+    return f.union(_.map(oneOfs, convertSchema));
+  } else if (schema.oneOf) {
     return f.union(_.map(schema.oneOf, convertSchema));
   }
 

--- a/src/__tests__/FlowSchema.spec.js
+++ b/src/__tests__/FlowSchema.spec.js
@@ -22,7 +22,45 @@ test('should convert allOf', (t) => {
   );
 });
 
-test('should convert multiple　properties by allOf', (t) => {
+test('should convert oneOf', t => {
+  t.deepEqual(
+    convertSchema({
+      id: 'OneOf',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+      },
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            string: {
+              type: 'string',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            number: {
+              type: 'number',
+            },
+          },
+        },
+      ],
+    }),
+
+    flow('any')
+    .union([
+      flow('Object').props({ foo: flow('string'), string: flow('string') }),
+      flow('Object').props({ foo: flow('string'), number: flow('number') }),
+    ])
+    .id('OneOf'),
+  );
+});
+
+test('should convert multiple properties by allOf', t => {
   t.deepEqual(
     convertSchema({
       id: 'AllOf',


### PR DESCRIPTION
Hi, thanks for this great tool! I hope you don't mind this unsolicited PR, but we are having to patch it at work, and thought instead I'd just try and fix it 😄.

Currently if you have a type like:
```json
  {
    "inheritance": {
      "type": "object",
      "properties": {
        "key1": {
          "type": "string"
        },
        "key2": {
          "type": "string"
        }
      },
      "oneOf": [
        {
          "type": "object",
          "properties": {
            "key3": "string"
          }
        },
        {
          "type": "object",
          "properties": {
            "key4": "string"
          }
        }
      ],
      "required": [
        "key1",
        "key2"
      ]
    }
  }
```

it creates a type like:

```flow
type Inheritance = 
    | {
		key3: string
	  }
	| {
	    key4: string
	  }
```

forgetting the other required properties that are "inherited". This fixes that, with a test.
	